### PR TITLE
Remove the default maximum parsing limit of 1,000 keys

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,9 @@ module.exports = function(input) {
   var output = {};
 
   if (typeof input === "string") {
-    data = querystring.parse(input);
+    // Parse without limits on the maximum number of keys, see:
+    // https://nodejs.org/api/querystring.html#querystring_querystring_parse_str_sep_eq_options
+    data = querystring.parse(input, null, null, { maxKeys: 0 });
   } else {
     data = input;
   }


### PR DESCRIPTION
This fixes a bug occurring when parsing Paypal NVP responses having more than 1,000 keys. In these cases, the parser would only consider the first 1,000 keys and ignore the rest.